### PR TITLE
172 add page preload

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
     "react-konva": "^19.0.1",
     "react-map-gl": "^8.0.2",
     "react-remove-scroll": "^2.6.2",
-    "router2": "^8.0.0",
+    "router2": "^8.1.0",
     "sonner": "^2.0.3",
     "swr": "^2.3.0"
   },

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2(@types/react@19.0.1)(react@19.0.0)
       router2:
-        specifier: ^8.0.0
-        version: 8.0.0(@types/react-dom@19.0.1)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)
+        specifier: ^8.1.0
+        version: 8.1.0(@types/react-dom@19.0.1)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)
       sonner:
         specifier: ^2.0.3
         version: 2.0.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2761,8 +2761,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  router2@8.0.0:
-    resolution: {integrity: sha512-TiX+SpIyO7GUV28lNQbJqT4ppAXWCyZeRpVhRJpvK49VwgBrf2uyiA5xcvv+QXQdwYJYteujnSVMsUqn56dpXw==}
+  router2@8.1.0:
+    resolution: {integrity: sha512-m/dSB9EUzNIR9Aw6LB9+sYvhcSe/NwBUU93WRv80hjzUXasrlbgvU9G+gUJjVFH0ATBkToJRjXt0LtrzWUe29w==}
     peerDependencies:
       '@types/react': ^19.0.1
       '@types/react-dom': ^19.0.1
@@ -6006,7 +6006,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.28.1
       fsevents: 2.3.3
 
-  router2@8.0.0(@types/react-dom@19.0.1)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2):
+  router2@8.1.0(@types/react-dom@19.0.1)(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2):
     dependencies:
       '@types/react': 19.0.1
       '@types/react-dom': 19.0.1

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,18 +1,8 @@
 import { lazy, Suspense } from "react";
 import { BrowserRouter } from "router2";
 
-import { config } from "~/service/router.ts";
+import { config, routes } from "~/service/router.ts";
 import { BACKDROP_ANIMATION_DURATION } from "~/ui/base/Backdrop.tsx";
-import { Home } from "~/ui/page/Home";
-import { Like } from "~/ui/page/Like";
-import { MyPage } from "~/ui/page/MyPage";
-import { NotFound } from "~/ui/page/NotFound.tsx";
-import { Register } from "~/ui/page/Register";
-import { Search } from "~/ui/page/Search";
-import { Setting } from "~/ui/page/Setting.tsx";
-import { SignIn } from "~/ui/page/SignIn";
-import { ThridPartyRegister } from "~/ui/page/ThirdPartyRegister";
-import { User } from "~/ui/page/User";
 import { AuthProvider } from "~/ui/provider/Auth.tsx";
 import { I18nProvider } from "~/ui/provider/I18nProvider.tsx";
 import { MessageProvider } from "~/ui/provider/Message.tsx";
@@ -28,21 +18,7 @@ const Introduction = lazy(() =>
 
 export const App = () => {
   return (
-    <BrowserRouter
-      config={config}
-      routes={{
-        "/": Home,
-        "/404": NotFound,
-        "/like": Like,
-        "/my-page": MyPage,
-        "/register": Register,
-        "/search": Search,
-        "/setting": Setting,
-        "/sign-in": SignIn,
-        "/third-party-register": ThridPartyRegister,
-        "/user/:userId": User,
-      }}
-    >
+    <BrowserRouter config={config} routes={routes}>
       {(Page) => (
         <I18nProvider>
           <NotificationProvider>

--- a/client/src/hook/base/useIntersectionObserver.ts
+++ b/client/src/hook/base/useIntersectionObserver.ts
@@ -1,12 +1,17 @@
 import { useEffect, useRef } from "react";
 
-export const useIntersectionObserver = (onObserve: () => unknown) => {
-  const intersectorRef = useRef<HTMLDivElement>(null);
+import { useLiveRef } from "~/hook/base/useLiveRef";
+
+export const useIntersectionObserver = <T extends HTMLElement = HTMLDivElement>(
+  onObserve: () => unknown,
+) => {
+  const intersectorRef = useRef<T>(null);
+  const onObserveRef = useLiveRef(onObserve);
 
   useEffect(() => {
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting) {
-        onObserve();
+        onObserveRef.current();
       }
     });
     if (intersectorRef.current) {
@@ -15,7 +20,7 @@ export const useIntersectionObserver = (onObserve: () => unknown) => {
         observer.disconnect();
       };
     }
-  }, [onObserve]);
+  }, [onObserveRef]);
 
   return intersectorRef;
 };

--- a/client/src/hook/domain/useRelatedPokeList.ts
+++ b/client/src/hook/domain/useRelatedPokeList.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 import { mutate } from "swr";
 import useSWRInfinite, { unstable_serialize } from "swr/infinite";
 
@@ -35,10 +35,9 @@ export const useRelatedPokeList = () => {
         : null,
     { revalidateAll: true },
   );
-  const loadMore = useCallback(
-    () => !isLoading && !error && void setSize((prev) => prev + 1),
-    [error, isLoading, setSize],
-  );
+  const loadMore = () =>
+    !isLoading && !error && void setSize((prev) => prev + 1);
+
   const intersectorRef = useIntersectionObserver(loadMore);
   const prevData = useRef(data);
 

--- a/client/src/service/router.ts
+++ b/client/src/service/router.ts
@@ -1,4 +1,15 @@
-import { Config } from "router2/lib/types";
+import { Config, RouterProps } from "router2/lib/types";
+
+import { Home } from "~/ui/page/Home";
+import { Like } from "~/ui/page/Like";
+import { MyPage } from "~/ui/page/MyPage";
+import { NotFound } from "~/ui/page/NotFound";
+import { Register } from "~/ui/page/Register";
+import { Search } from "~/ui/page/Search";
+import { Setting } from "~/ui/page/Setting";
+import { SignIn } from "~/ui/page/SignIn";
+import { ThridPartyRegister } from "~/ui/page/ThirdPartyRegister";
+import { User } from "~/ui/page/User";
 
 const scroll = new Map<string, number>();
 
@@ -42,4 +53,17 @@ export const config: Config = {
       next();
     },
   },
+};
+
+export const routes: RouterProps["routes"] = {
+  "/": Home,
+  "/404": NotFound,
+  "/like": Like,
+  "/my-page": MyPage,
+  "/register": Register,
+  "/search": Search,
+  "/setting": Setting,
+  "/sign-in": SignIn,
+  "/third-party-register": ThridPartyRegister,
+  "/user/:userId": User,
 };

--- a/client/src/service/swr/fetcher.ts
+++ b/client/src/service/swr/fetcher.ts
@@ -1,0 +1,6 @@
+import { KyInstance } from "ky";
+
+export const createFetcher =
+  (client: KyInstance) =>
+  ([key, params]: [string, Record<string, string>]) =>
+    client.get(key, { searchParams: params }).json();

--- a/client/src/service/util.ts
+++ b/client/src/service/util.ts
@@ -100,3 +100,18 @@ export const createdAt = (dep: undefined | WeakKey) => {
   map.set(dep, createdAt);
   return createdAt;
 };
+
+export const memoize = <A, R>(fn: (arg: A) => R) => {
+  const cache = new Map<A, R>();
+  const memoizedFn = (arg: A): R => {
+    const key = arg;
+    if (cache.has(key)) {
+      return cache.get(key)!;
+    }
+    const result = fn(arg);
+    cache.set(key, result);
+    return result;
+  };
+
+  return memoizedFn;
+};

--- a/client/src/ui/base/PreloadLink.tsx
+++ b/client/src/ui/base/PreloadLink.tsx
@@ -1,0 +1,41 @@
+import { KyInstance } from "ky";
+import { ReactNode } from "react";
+import { getParams, Link, matchDynamicRoute } from "router2";
+import { Router } from "router2/lib/types";
+
+import { useIntersectionObserver } from "~/hook/base/useIntersectionObserver";
+import { routes } from "~/service/router";
+import { memoize } from "~/service/util";
+import { useUser } from "~/ui/provider/Auth";
+
+export type PreloadablePage = (() => ReactNode) & {
+  preload?: (
+    history: Pick<Router, "params" | "path" | "pathname">,
+    client: KyInstance,
+  ) => Promise<void>;
+};
+
+const getRoute = memoize((pathname: string) => {
+  return (Object.entries(routes)
+    .sort((a, b) => (a[0] > b[0] ? -1 : 1))
+    .find(([path]) => matchDynamicRoute(path, pathname)) ?? [
+    undefined,
+    routes["/404"],
+  ]) as [string, PreloadablePage];
+});
+
+export const PreloadLink = (props: Parameters<typeof Link>[0]) => {
+  const { pathname, query } = props;
+
+  const { client } = useUser();
+
+  const [path, Page] = getRoute(pathname);
+
+  const params = getParams({ pathname, query }, path);
+
+  const observer = useIntersectionObserver<HTMLAnchorElement>(() => {
+    void Page?.preload?.({ params, path, pathname }, client);
+  });
+
+  return <Link {...props} ref={observer} />;
+};

--- a/client/src/ui/domain/PokeListItem.tsx
+++ b/client/src/ui/domain/PokeListItem.tsx
@@ -1,11 +1,11 @@
 import { CheckBadgeIcon } from "@heroicons/react/20/solid";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { Link } from "router2";
 
 import { DELETED_USER } from "~/service/const.ts";
 import { Poke, User } from "~/service/dataType.ts";
 import { getReadableDateOffset } from "~/service/util.ts";
 import { type Line } from "~/ui/base/Canvas.tsx";
+import { PreloadLink } from "~/ui/base/PreloadLink";
 import { PokeSheet } from "~/ui/overlay/PokeSheet.tsx";
 import { ShowDrawingSheet } from "~/ui/overlay/ShowDrawingSheet.tsx";
 import { ShowGeolocationSheet } from "~/ui/overlay/ShowGeolocationSheet.tsx";
@@ -229,7 +229,7 @@ export const PokeListItem = ({
         />
         <div className="ml-4 flex-1">
           <p className="relative">
-            <Link
+            <PreloadLink
               className="flex items-center font-medium"
               pathname={`/user/${targetUser.email}`}
               role="link"
@@ -240,7 +240,7 @@ export const PokeListItem = ({
                   <CheckBadgeIcon className="size-[1.125rem]" />
                 </span>
               )}
-            </Link>
+            </PreloadLink>
             <span className="absolute top-1 right-0 text-xs font-normal text-zinc-400">
               {t(getReadableDateOffset(date))}
             </span>

--- a/client/src/ui/domain/UserListItem.tsx
+++ b/client/src/ui/domain/UserListItem.tsx
@@ -1,6 +1,7 @@
 import { CheckBadgeIcon } from "@heroicons/react/20/solid";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
-import { Link } from "router2";
+
+import { PreloadLink } from "~/ui/base/PreloadLink";
 
 interface UserListItemProps {
   animation: {
@@ -57,13 +58,13 @@ export const UserListItem = ({
           <p className="text-sm text-zinc-800">{userName}</p>
         </div>
         {selected && (
-          <Link
+          <PreloadLink
             className="self-center p-1 text-zinc-400"
             pathname={`/user/${userEmail}`}
             role="button"
           >
             <ChevronRightIcon className="size-6" />
-          </Link>
+          </PreloadLink>
         )}
       </div>
     </button>

--- a/client/src/ui/page/User.tsx
+++ b/client/src/ui/page/User.tsx
@@ -2,14 +2,17 @@ import { CheckBadgeIcon, ChevronDownIcon } from "@heroicons/react/20/solid";
 import { Trans, useLingui } from "@lingui/react/macro";
 import dayjs, { isDayjs } from "dayjs";
 import { useRouter } from "router2";
+import { preload } from "swr";
 import useSWRMutation from "swr/mutation";
 
 import { useRelatedPokeList } from "~/hook/domain/useRelatedPokeList.ts";
-import { useUserPofile } from "~/hook/domain/useUserProfile.ts";
+import { SWR_KEY_USER, useUserPofile } from "~/hook/domain/useUserProfile.ts";
 import { useUserRelatedPokeList } from "~/hook/domain/useUserRelatedPokeList.ts";
+import { createFetcher } from "~/service/swr/fetcher";
 import { isVerifiedUser } from "~/service/util.ts";
 import { Image } from "~/ui/base/Image";
 import { StackedNavigation } from "~/ui/base/Navigation.tsx";
+import { PreloadablePage } from "~/ui/base/PreloadLink";
 import { Stat } from "~/ui/base/Stat.tsx";
 import { Timer } from "~/ui/base/Timer.tsx";
 import { PokeSheet } from "~/ui/overlay/PokeSheet.tsx";
@@ -18,7 +21,7 @@ import { useAuthNavigator, useUser } from "~/ui/provider/Auth.tsx";
 import { useNotification } from "~/ui/provider/Notification.tsx";
 import { useStackedLayer } from "~/ui/provider/StackedLayerProvider.tsx";
 
-export const User = () => {
+export const User: PreloadablePage = () => {
   useAuthNavigator({ goToAuth: true });
 
   const { params } = useRouter();
@@ -152,4 +155,13 @@ export const User = () => {
       </div>
     </div>
   );
+};
+
+User.preload = async (history, client) => {
+  const { params } = history;
+  const userEmail = params[":userId"];
+  if (typeof userEmail !== "string") {
+    return;
+  }
+  await preload(SWR_KEY_USER(userEmail), createFetcher(client));
 };

--- a/client/src/ui/provider/Auth.tsx
+++ b/client/src/ui/provider/Auth.tsx
@@ -13,6 +13,7 @@ import { SWRConfig } from "swr";
 
 import { client } from "~/service/api.ts";
 import { MyInfo } from "~/service/dataType.ts";
+import { createFetcher } from "~/service/swr/fetcher";
 import { persisteToken } from "~/ui/provider/PwaProvider.tsx";
 
 interface PatchUserPayload {
@@ -183,8 +184,7 @@ export const AuthProvider = ({
     >
       <SWRConfig
         value={{
-          fetcher: ([key, params]: [string, Record<string, string>]) =>
-            userClient.get(key, { searchParams: params }).json(),
+          fetcher: createFetcher(userClient),
         }}
       >
         {children}


### PR DESCRIPTION
closes #172 

## 변경사항
- router2 의존성 업데이트
- use-intersection-observer callback 참조 로직 개선
- browserrouter routes 변수 분리
- intersection observer기반 preload 컴포넌트 추가
- ky client 생성자 추가

## 주목할 점
intersection observer와 router2 의 getParams 호출, routes를 탐색하여 path를 찾는 로직이 컴포넌트 레벨에 추가되어 성능 이슈가 우려됨. 하지만, 해당 컴포넌트 호출이 /user/:userid는 1회, /my-page 는 뷰포트에 따라 다르지만 10회 내외로 예상되어, 체감하기는 어려울 것으로 예상됨. 하지만 가능한 중복 연산을 줄이고자 getRoute에 memoization을 적용함. 아래는 적용 전후의 performace에 대한 간략한 측정치이다. 의미있는 성능상 변화가 없음을 알 수 있다. (m2 macbook air)

| 페이지 | 적용 이전 성능  | 적용 이후 |
| - | ------------- | ------------- |
| /user/:userId, preload 요소 1개 (요소 focus 시에만 preload 가 트리거됨) | <img width="194" alt="스크린샷 2025-04-20 17 00 16" src="https://github.com/user-attachments/assets/c536c0d9-689f-4bf1-88ec-19a95c200066" /> |  <img width="199" alt="스크린샷 2025-04-20 17 00 40" src="https://github.com/user-attachments/assets/d1978acd-9069-4182-be4b-9daa07d3f987" /> |
| /my-page, preload 요소 3개  |  <img width="197" alt="스크린샷 2025-04-20 17 14 52" src="https://github.com/user-attachments/assets/845e005c-8ce8-4f4c-85e8-86f179fad570" /> | <img width="194" alt="스크린샷 2025-04-20 17 15 11" src="https://github.com/user-attachments/assets/ec08957f-0642-42b9-965f-b98a8005a246" />  |