### PR TITLE
refactor: createUseSWRMiddleware 추가

### DIFF
--- a/client/src/service/swr/middleware.ts
+++ b/client/src/service/swr/middleware.ts
@@ -1,46 +1,31 @@
 import useSWR, { Key, Middleware } from "swr";
-import { Fetcher, SWRConfiguration, SWRResponse } from "swr/_internal";
+import { SWRConfiguration, SWRResponse } from "swr/_internal";
 
 export type TypedMiddleware<T> = { __type: T } & Middleware;
 
-type ArgumentsTuple = readonly [unknown, ...unknown[]];
-type MergeMiddleware<T extends TypedMiddleware<unknown>[]> = MergeProperties<
-  T[number] extends TypedMiddleware<infer P> ? P : never
->;
-type MergeProperties<T> = {
-  [K in T as keyof K]: K[keyof K];
-};
-type StrictKey = (() => StrictTupleKey) | StrictTupleKey;
-
-type StrictTupleKey = ArgumentsTuple | false | null | undefined;
-type SWRConfigurationWithOptionalFallback<Options> = Options extends Required<
-  Pick<SWRConfiguration, "fallbackData">
-> &
-  SWRConfiguration
-  ? Omit<Options, "fallbackData"> & Pick<Partial<Options>, "fallbackData">
-  : Options;
-
-type UseSWRMiddleware = <
-  Data = unknown,
-  Middewares extends TypedMiddleware<unknown>[] = TypedMiddleware<unknown>[],
-  SWRKey extends Key = StrictKey,
-  Error = unknown,
-  SWROptions extends
-    | ({ use: Middewares } & Omit<
-        SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>,
-        "use"
-      >)
-    | undefined =
-    | ({ use: Middewares } & Omit<
-        SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>,
-        "use"
-      >)
-    | undefined,
->(
-  key: SWRKey,
-  config: SWRConfigurationWithOptionalFallback<SWROptions>,
-) => MergeMiddleware<Middewares> & SWRResponse<Data, Error, SWROptions>;
-
 export const createTypedMiddleware = <T>(middleware: Middleware) =>
   middleware as TypedMiddleware<T>;
-export const useSWRMiddleware = useSWR as UseSWRMiddleware;
+
+type UnionToIntersection<U> = (
+  U extends unknown ? (k: U) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never;
+
+export const createUseSWRMiddleware = <T extends TypedMiddleware<unknown>[]>(
+  ...middlewares: T
+) => {
+  type TI = UnionToIntersection<
+    T[number] extends TypedMiddleware<infer I> ? I : never
+  >;
+  return <D, E = Error, K extends Key = Key>(
+    key: K,
+    config?: SWRConfiguration<D, E>,
+  ) =>
+    useSWR(key, { ...config, use: middlewares }) as SWRResponse<
+      D,
+      E,
+      SWRConfiguration<D, E>
+    > &
+      TI;
+};

--- a/client/src/ui/page/Like.tsx
+++ b/client/src/ui/page/Like.tsx
@@ -3,9 +3,9 @@ import { Trans } from "@lingui/react/macro";
 import { useRouter } from "router2";
 
 import { User } from "~/service/dataType.ts";
+import { createUseSWRMiddleware } from "~/service/swr/middleware";
 import { dataUpdatedAtMiddleware } from "~/service/swr/middleware.dataUpdatedAt.ts";
 import { createShouldAnimateMiddleware } from "~/service/swr/middleware.shouldAnimate.ts";
-import { useSWRMiddleware } from "~/service/swr/middleware.ts";
 import { isVerifiedUser } from "~/service/util.ts";
 import { Navigation } from "~/ui/base/Navigation.tsx";
 import { DomainBottomNavigation } from "~/ui/domain/DomainBottomNavigation.tsx";
@@ -15,19 +15,21 @@ import { useAuthNavigator } from "~/ui/provider/Auth";
 type Key = [string, { email: string; isFollowing: boolean }] | null;
 const isEqualKey = (a: Key, b: Key) =>
   a?.[0] === b?.[0] && a?.[1].isFollowing === b?.[1].isFollowing;
-const middlewares = [
+
+const useSWRMiddleware = createUseSWRMiddleware(
   createShouldAnimateMiddleware(isEqualKey),
   dataUpdatedAtMiddleware,
-];
+);
+
 export const Like = () => {
   useAuthNavigator({ goToAuth: true });
   const { push } = useRouter();
 
   const { data, dataUpdatedAt, shouldAnimate } = useSWRMiddleware<
     User[],
-    typeof middlewares,
+    unknown,
     Key
-  >(["user", { email: "", isFollowing: true }], { use: middlewares });
+  >(["user", { email: "", isFollowing: true }]);
 
   return (
     <>

--- a/client/src/ui/page/Search.tsx
+++ b/client/src/ui/page/Search.tsx
@@ -8,7 +8,7 @@ import { usePoke } from "~/hook/domain/usePoke.ts";
 import { User } from "~/service/dataType.ts";
 import { dataUpdatedAtMiddleware } from "~/service/swr/middleware.dataUpdatedAt.ts";
 import { createShouldAnimateMiddleware } from "~/service/swr/middleware.shouldAnimate.ts";
-import { useSWRMiddleware } from "~/service/swr/middleware.ts";
+import { createUseSWRMiddleware } from "~/service/swr/middleware.ts";
 import { isVerifiedUser } from "~/service/util.ts";
 import { Navigation } from "~/ui/base/Navigation.tsx";
 import { DomainBottomNavigation } from "~/ui/domain/DomainBottomNavigation.tsx";
@@ -37,10 +37,10 @@ type Key = [string, { email: string; limit: number; name: string }];
 const isEqualKey = (a: Key, b: Key) =>
   a[1].email === b[1].email && a[1].name === b[1].name;
 
-const middlewares = [
+const useSWRMiddleware = createUseSWRMiddleware(
   createShouldAnimateMiddleware(isEqualKey),
   dataUpdatedAtMiddleware,
-];
+);
 
 export const Search = () => {
   useAuthNavigator({ goToAuth: "/sign-in" });
@@ -60,7 +60,7 @@ export const Search = () => {
 
   const { data, dataUpdatedAt, isLoading, shouldAnimate } = useSWRMiddleware<
     User[],
-    typeof middlewares,
+    unknown,
     Key
   >(
     ["user", { email: deferredSearchText, limit: 5, name: deferredSearchText }],
@@ -70,7 +70,6 @@ export const Search = () => {
         setSelected(null);
         setPokeOptionOpen(false);
       },
-      use: middlewares,
     },
   );
 


### PR DESCRIPTION
closes #175 

useSWRMiddleware 대신, createUseSWRMiddleware 훅을 사용해서 type safe 한 middleware 훅을 생성해 사용한다.
미들웨어 관련 로직을 한 곳으로 집중시킬 수 있다.