### PR TITLE
feat: cloudfront에서 minio에 요청을 보내면 host 를 잘못잡음

### DIFF
--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -6,7 +6,7 @@ events {
 }
 
 http {
-    log_format main '$remote_addr test! [$time_local] '
+    log_format compression '$remote_addr test! [$time_local] '
                 '$host "$http_host" "$server_name" '
                 '"$request_uri" $status "$http_referer" "$http_user_agent"';
     server {

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -45,7 +45,7 @@ http {
         proxy_request_buffering off;
 
         location / {
-            proxy_set_header Host $host;
+            proxy_set_header Host static.is-not-a.store;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -6,11 +6,11 @@ events {
 }
 
 http {
-    log_format combined '$remote_addr - $remote_user [$time_local] $host $server_name $http_host testing!!'
+    log_format combinedss '$remote_addr - $remote_user [$time_local] $host $server_name $http_host testing!!'
                        '"$request" $status $bytes_sent '
                        '"$http_referer" "$http_user_agent" "$gzip_ratio"';
 
-    access_log logs/access.log combined;
+    access_log logs/access.log combinedss;
 
     server {
         listen 443 ssl;

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -45,7 +45,7 @@ http {
         proxy_request_buffering off;
 
         location / {
-            proxy_set_header Host $http_host;
+            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -68,7 +68,7 @@ http {
         ssl_certificate /etc/nginx/certs/live/yogi-poke-api.is-not-a.store/fullchain.pem;
         ssl_certificate_key /etc/nginx/certs/live/yogi-poke-api.is-not-a.store/privkey.pem;
 
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -10,6 +10,8 @@ http {
                        '"$request" $status $bytes_sent '
                        '"$http_referer" "$http_user_agent" "$gzip_ratio"';
 
+    access_log logs/access.log combined;
+
     server {
         listen 443 ssl;
         server_name yogi-poke-api.is-not-a.store;

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -6,9 +6,10 @@ events {
 }
 
 http {
-    log_format compression '$remote_addr test! [$time_local] '
-                '$host "$http_host" "$server_name" '
-                '"$request_uri" $status "$http_referer" "$http_user_agent"';
+    log_format combined '$remote_addr - $remote_user [$time_local] $host $server_name $http_host testing!!'
+                       '"$request" $status $bytes_sent '
+                       '"$http_referer" "$http_user_agent" "$gzip_ratio"';
+
     server {
         listen 443 ssl;
         server_name yogi-poke-api.is-not-a.store;

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -45,7 +45,7 @@ http {
         proxy_request_buffering off;
 
         location / {
-            proxy_set_header Host static.is-not-a.store;
+            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -6,12 +6,6 @@ events {
 }
 
 http {
-    log_format combinedss '$remote_addr - $remote_user [$time_local] $host $server_name $http_host testing!!'
-                       '"$request" $status $bytes_sent '
-                       '"$http_referer" "$http_user_agent" "$gzip_ratio"';
-
-    access_log logs/access.log combinedss;
-
     server {
         listen 443 ssl;
         server_name yogi-poke-api.is-not-a.store;

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -6,7 +6,7 @@ events {
 }
 
 http {
-    log_format main '$remote_addr [$time_local] '
+    log_format main '$remote_addr test! [$time_local] '
                 '$host "$http_host" "$server_name" '
                 '"$request_uri" $status "$http_referer" "$http_user_agent"';
     server {

--- a/web-server/nginx.conf
+++ b/web-server/nginx.conf
@@ -6,6 +6,9 @@ events {
 }
 
 http {
+    log_format main '$remote_addr [$time_local] '
+                '$host "$http_host" "$server_name" '
+                '"$request_uri" $status "$http_referer" "$http_user_agent"';
     server {
         listen 443 ssl;
         server_name yogi-poke-api.is-not-a.store;


### PR DESCRIPTION
nginx 의 proxy header 때문에 다른 도메인 서버에서 요청을 보내면 cloudfront의 도메인이 덮어써져서 minio에서 요청을 거부하는 것이 의심됨.