### PR TITLE
feat: 데이터가 undefined 인 경우만 애니메이션 실행

### DIFF
--- a/client/src/ui/base/Stat.tsx
+++ b/client/src/ui/base/Stat.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { CountUp } from "~/ui/base/CountUp.tsx";
 
 export const Stat = ({
@@ -7,10 +9,14 @@ export const Stat = ({
   label: string;
   value: null | number | undefined;
 }) => {
+  const [hasValueOnFirstRender] = useState(typeof value === "number");
   return (
     <div className="flex flex-col items-center">
       <p className="text-xl font-extrabold">
-        <CountUp duration={1500} height={28} value={value ?? null} />
+        {hasValueOnFirstRender && value?.toLocaleString()}
+        {!hasValueOnFirstRender && (
+          <CountUp duration={1500} height={28} value={value ?? null} />
+        )}
       </p>
       <p>{label}</p>
     </div>


### PR DESCRIPTION
swr에서 preload 한 데이터가 처음 렌더링 되기 전에는 undefined로 동작함.
그래서 프리로드된 유저 페이지에 들어가도 첫 접근시에는 애니메이션이 재생됨.
그런데 이런 동작이 나쁘지 않아서 이대로 머지함.